### PR TITLE
Fix(ubuntu-18.04): update iso details

### DIFF
--- a/Ubuntu/bionic64/server/template.json
+++ b/Ubuntu/bionic64/server/template.json
@@ -1,8 +1,8 @@
 {
   "boot_command_prefix": "<enter><wait><f6><esc><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-  "iso_checksum": "a2cb36dc010d98ad9253ea5ad5a07fd6b409e3412c48f1860536970b073c98f5",
+  "iso_checksum": "7d8e0055d663bffa27c1718685085626cb59346e7626ba3d3f476322271f573e",
   "iso_checksum_type": "sha256",
-  "iso_url": "http://cdimage.ubuntu.com/releases/18.04/release/ubuntu-18.04.2-server-amd64.iso",
+  "iso_url": "http://cdimage.ubuntu.com/releases/18.04/release/ubuntu-18.04.3-server-amd64.iso",
   "iso_checksum_url": "http://cdimage.ubuntu.com/releases/18.04/release/SHA256SUMS",
   "vm_name": "ubuntu-bionic64"
 }


### PR DESCRIPTION
Ubuntu 18.04.3 is out.
This commit updates the ISO download URL and SHA sum to reflect this.