### PR TITLE
update(iso): update iso URL and SHA values

### DIFF
--- a/Debian/jessie64/server/template.json
+++ b/Debian/jessie64/server/template.json
@@ -1,8 +1,8 @@
 {
   "boot_command_prefix": "<esc><wait>",
-  "iso_checksum": "ea799ed959d77359783e7922ed4c94a7437b083a4ce6f09e9fe41a7af6ba60df",
+  "iso_checksum": "ea444d6f8ac95fd51d2aedb8015c57410d1ad19b494cedec6914c17fda02733c",
   "iso_checksum_type": "sha256",
-  "iso_url": "https://cdimage.debian.org/cdimage/archive/8.11.0/amd64/iso-cd/debian-8.11.0-amd64-netinst.iso",
-  "iso_checksum_url": "https://cdimage.debian.org/cdimage/archive/8.11.0/amd64/iso-cd/SHA256SUMS",
+  "iso_url": "https://cdimage.debian.org/cdimage/archive/8.11.1/amd64/iso-cd/debian-8.11.1-amd64-netinst.iso",
+  "iso_checksum_url": "https://cdimage.debian.org/cdimage/archive/8.11.1/amd64/iso-cd/SHA256SUMS",
   "vm_name": "debian-jessie64"
 }

--- a/Debian/stretch64/desktop/template.json
+++ b/Debian/stretch64/desktop/template.json
@@ -1,8 +1,8 @@
 {
   "boot_command_prefix": "<esc><wait>", 
-  "iso_checksum": "d4a22c81c76a66558fb92e690ef70a5d67c685a08216701b15746586520f6e8e", 
+  "iso_checksum": "9ae83aa5a732151ef2dc84538d1d4ffd6374df47cc01681da6348f9ec5a45bd4", 
   "iso_checksum_type": "sha256", 
-  "iso_checksum_url": "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/SHA256SUMS", 
-  "iso_url": "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-9.9.0-amd64-netinst.iso", 
+  "iso_checksum_url": "https://cdimage.debian.org/cdimage/archive/9.11.0/amd64/iso-cd/SHA256SUMS", 
+  "iso_url": "https://cdimage.debian.org/cdimage/archive/9.11.0/amd64/iso-cd/debian-9.11.0-amd64-netinst.iso", 
   "vm_name": "debian-stretch64"
 }

--- a/Debian/stretch64/server/template.json
+++ b/Debian/stretch64/server/template.json
@@ -1,8 +1,8 @@
 {
   "boot_command_prefix": "<esc><wait>", 
-  "iso_checksum": "d4a22c81c76a66558fb92e690ef70a5d67c685a08216701b15746586520f6e8e", 
+  "iso_checksum": "9ae83aa5a732151ef2dc84538d1d4ffd6374df47cc01681da6348f9ec5a45bd4", 
   "iso_checksum_type": "sha256", 
-  "iso_checksum_url": "https://cdimage.debian.org/cdimage/archive/9.9.0/amd64/iso-cd/SHA256SUMS", 
-  "iso_url": "https://cdimage.debian.org/cdimage/archive/9.9.0/amd64/iso-cd/debian-9.9.0-amd64-netinst.iso", 
+  "iso_checksum_url": "https://cdimage.debian.org/cdimage/archive/9.11.0/amd64/iso-cd/SHA256SUMS", 
+  "iso_url": "https://cdimage.debian.org/cdimage/archive/9.11.0/amd64/iso-cd/debian-9.11.0-amd64-netinst.iso", 
   "vm_name": "debian-stretch64"
 }

--- a/Ubuntu/bionic64/desktop/template.json
+++ b/Ubuntu/bionic64/desktop/template.json
@@ -1,8 +1,8 @@
 {
   "boot_command_prefix": "<enter><wait><f6><esc><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-  "iso_checksum": "a2cb36dc010d98ad9253ea5ad5a07fd6b409e3412c48f1860536970b073c98f5",
+  "iso_checksum": "7d8e0055d663bffa27c1718685085626cb59346e7626ba3d3f476322271f573e",
   "iso_checksum_type": "sha256",
-  "iso_url": "http://cdimage.ubuntu.com/releases/18.04/release/ubuntu-18.04.2-server-amd64.iso",
+  "iso_url": "http://cdimage.ubuntu.com/releases/18.04/release/ubuntu-18.04.3-server-amd64.iso",
   "iso_checksum_url": "http://cdimage.ubuntu.com/releases/18.04/release/SHA256SUMS",
   "vm_name": "ubuntu-bionic64"
 }

--- a/Ubuntu/bionic64/server/template.json
+++ b/Ubuntu/bionic64/server/template.json
@@ -1,8 +1,8 @@
 {
   "boot_command_prefix": "<enter><wait><f6><esc><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-  "iso_checksum": "a2cb36dc010d98ad9253ea5ad5a07fd6b409e3412c48f1860536970b073c98f5",
+  "iso_checksum": "7d8e0055d663bffa27c1718685085626cb59346e7626ba3d3f476322271f573e",
   "iso_checksum_type": "sha256",
-  "iso_url": "http://cdimage.ubuntu.com/releases/18.04/release/ubuntu-18.04.2-server-amd64.iso",
+  "iso_url": "http://cdimage.ubuntu.com/releases/18.04/release/ubuntu-18.04.3-server-amd64.iso",
   "iso_checksum_url": "http://cdimage.ubuntu.com/releases/18.04/release/SHA256SUMS",
   "vm_name": "ubuntu-bionic64"
 }

--- a/Ubuntu/cosmic64/desktop/template.json
+++ b/Ubuntu/cosmic64/desktop/template.json
@@ -2,7 +2,7 @@
   "boot_command_prefix": "<enter><wait><f6><esc><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
   "iso_checksum": "cf9250781dadd919f23c9d9612212cad653e35fccc2fbcf6853f67ad09e067ba",
   "iso_checksum_type": "sha256",
-  "iso_url": "http://cdimage.ubuntu.com/releases/18.10/release/ubuntu-18.10-server-amd64.iso",
-  "iso_checksum_url": "http://cdimage.ubuntu.com/releases/18.10/release/SHA256SUMS",
+  "iso_url": "http://old-releases.ubuntu.com/releases/18.10/ubuntu-18.10-server-amd64.iso",
+  "iso_checksum_url": "http://old-releases.ubuntu.com/releases/18.10/SHA256SUMS",
   "vm_name": "ubuntu-cosmic64"
 }

--- a/Ubuntu/cosmic64/server/template.json
+++ b/Ubuntu/cosmic64/server/template.json
@@ -2,7 +2,7 @@
   "boot_command_prefix": "<enter><wait><f6><esc><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
   "iso_checksum": "cf9250781dadd919f23c9d9612212cad653e35fccc2fbcf6853f67ad09e067ba",
   "iso_checksum_type": "sha256",
-  "iso_url": "http://cdimage.ubuntu.com/releases/18.10/release/ubuntu-18.10-server-amd64.iso",
-  "iso_checksum_url": "http://cdimage.ubuntu.com/releases/18.10/release/SHA256SUMS",
+  "iso_url": "http://old-releases.ubuntu.com/releases/18.10/ubuntu-18.10-server-amd64.iso",
+  "iso_checksum_url": "http://old-releases.ubuntu.com/releases/18.10/SHA256SUMS",
   "vm_name": "ubuntu-cosmic64"
 }


### PR DESCRIPTION
Update ISO urls to latest versions for Debian and Ubuntu.
Update SHA sums to match